### PR TITLE
Make step-issuer compile again, fix OOMKills and allow events from manager

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,8 +32,8 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 50Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 30Mi
       terminationGracePeriodSeconds: 10

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,6 +9,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get

--- a/provisioners/step.go
+++ b/provisioners/step.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"sync"
 
-	certmanager "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	certmanager "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	capi "github.com/smallstep/certificates/api"
 	"github.com/smallstep/certificates/ca"
 	api "github.com/smallstep/step-issuer/api/v1beta1"


### PR DESCRIPTION
Step-issuer on this branch seems to work great with Cert-Manager 14.1 and Kubernetes 1.15-1.17 clusters after the fixes from this pull-request