### PR TITLE
Bump cert-manager API version v1alpha2 -> v1 in example configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ sign the certificate requests.
 
 In this guide, we assume that you have a [Kubernetes](https://kubernetes.io/)
 environment with a [cert-manager](https://github.com/jetstack/cert-manager)
-version supporting CertificateRequest issuers, cert-manager v0.11.0 or higher.
+version supporting CertificateRequest issuers, cert-manager `v1.0.0` or higher.
 
 ### Installing step certificates
 
@@ -299,7 +299,7 @@ as the root certificate will be available in the resource:
 
 ```sh
 $ kubectl get certificaterequests.cert-manager.io internal-smallstep-com -o yaml
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: CertificateRequest
 ...
 status:

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -1,6 +1,6 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -8,7 +8,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -52,7 +52,7 @@ vars:
 #  objref:
 #    kind: Certificate
 #    group: cert-manager.io
-#    version: v1alpha2
+#    version: v1
 #    name: serving-cert # this name should match the one in certificate.yaml
 #  fieldref:
 #    fieldpath: metadata.namespace
@@ -60,7 +60,7 @@ vars:
 #  objref:
 #    kind: Certificate
 #    group: cert-manager.io
-#    version: v1alpha2
+#    version: v1
 #    name: serving-cert # this name should match the one in certificate.yaml
 #- name: SERVICE_NAMESPACE # namespace of the service
 #  objref:


### PR DESCRIPTION
`cert-manager` is deprecating all alpha and beta API versions in the next release (see [cert-manager#4021](https://github.com/jetstack/cert-manager/pull/4021)).

This PR bumps API versions in sample configs `v1alpha2` -> `v1`.

It also updates `cert-manager` version in README to `v1` as that was the first version where `v1` API became available.

Signed-off-by: irbekrm <irbekrm@gmail.com>