### PR TITLE
Allow signing of intermediate CA

### DIFF
--- a/controllers/certificaterequest_controller.go
+++ b/controllers/certificaterequest_controller.go
@@ -103,12 +103,6 @@ func (r *CertificateRequestReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, nil
 	}
 
-	// Step CA does not support online signing of CA certificate at this time
-	if cr.Spec.IsCA {
-		log.Info("step certificate does not support online signing of CA certificates")
-		return ctrl.Result{}, nil
-	}
-
 	if cr.Spec.IssuerRef.Kind == "StepClusterIssuer" {
 		iss := api.StepClusterIssuer{}
 		issNamespaceName := types.NamespacedName{


### PR DESCRIPTION
This commit removes the check if the certificate has the CA flag. This is possible because step-ca supports signing CAs. 

<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:
Allow signing of CAs

#### Pain or issue this feature alleviates:
Signing certificates with CA flag

#### Why is this important to the project (if not answered above):
more step-ca features are usable

#### Supporting links/other PRs/issues:
Closes #9 

💔Thank you!
