### PR TITLE
Remove the requirement of an identity certificate

### DIFF
--- a/api/v1beta1/stepclusterissuer_types.go
+++ b/api/v1beta1/stepclusterissuer_types.go
@@ -40,8 +40,7 @@ type StepClusterIssuerSpec struct {
 	// CABundle is a base64 encoded TLS certificate used to verify connections
 	// to the step certificates server. If not set the system root certificates
 	// are used to validate the TLS connection.
-	// +optional
-	CABundle []byte `json:"caBundle,omitempty"`
+	CABundle []byte `json:"caBundle"`
 }
 
 // StepClusterIssuerStatus defines the observed state of StepClusterIssuer

--- a/api/v1beta1/stepissuer_types.go
+++ b/api/v1beta1/stepissuer_types.go
@@ -40,8 +40,7 @@ type StepIssuerSpec struct {
 	// CABundle is a base64 encoded TLS certificate used to verify connections
 	// to the step certificates server. If not set the system root certificates
 	// are used to validate the TLS connection.
-	// +optional
-	CABundle []byte `json:"caBundle,omitempty"`
+	CABundle []byte `json:"caBundle"`
 }
 
 // StepIssuerStatus defines the observed state of StepIssuer

--- a/config/crd/bases/certmanager.step.sm_stepclusterissuers.yaml
+++ b/config/crd/bases/certmanager.step.sm_stepclusterissuers.yaml
@@ -81,6 +81,7 @@ spec:
                 description: URL is the base URL for the step certificates instance.
                 type: string
             required:
+            - caBundle
             - provisioner
             - url
             type: object

--- a/config/crd/bases/certmanager.step.sm_stepissuers.yaml
+++ b/config/crd/bases/certmanager.step.sm_stepissuers.yaml
@@ -76,6 +76,7 @@ spec:
                 description: URL is the base URL for the step certificates instance.
                 type: string
             required:
+            - caBundle
             - provisioner
             - url
             type: object

--- a/controllers/stepclusterissuer_controller.go
+++ b/controllers/stepclusterissuer_controller.go
@@ -87,7 +87,6 @@ func (r *StepClusterIssuerReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	// Initialize and store the provisioner
-	//nolint:contextcheck // legacy
 	p, err := provisioners.NewFromStepClusterIssuer(iss, password)
 	if err != nil {
 		log.Error(err, "failed to initialize provisioner")
@@ -111,6 +110,8 @@ func validateStepClusterIssuerSpec(s api.StepClusterIssuerSpec) error {
 	switch {
 	case s.URL == "":
 		return fmt.Errorf("spec.url cannot be empty")
+	case len(s.CABundle) == 0:
+		return fmt.Errorf("spec.caBundle cannot be empty")
 	case s.Provisioner.Name == "":
 		return fmt.Errorf("spec.provisioner.name cannot be empty")
 	case s.Provisioner.KeyID == "":

--- a/controllers/stepissuer_controller.go
+++ b/controllers/stepissuer_controller.go
@@ -87,7 +87,6 @@ func (r *StepIssuerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	// Initialize and store the provisioner
-	//nolint:contextcheck // legacy
 	p, err := provisioners.NewFromStepIssuer(iss, password)
 	if err != nil {
 		log.Error(err, "failed to initialize provisioner")
@@ -111,6 +110,8 @@ func validateStepIssuerSpec(s api.StepIssuerSpec) error {
 	switch {
 	case s.URL == "":
 		return fmt.Errorf("spec.url cannot be empty")
+	case len(s.CABundle) == 0:
+		return fmt.Errorf("spec.caBundle cannot be empty")
 	case s.Provisioner.Name == "":
 		return fmt.Errorf("spec.provisioner.name cannot be empty")
 	case s.Provisioner.KeyID == "":


### PR DESCRIPTION
### Description

This commit removes the requirement of having an identity certificate per issuer. This certificate was used to make the request "GET /roots" that might require an mTLS certificate in some deployments. The change removes these requests and uses the defined bundle in the issuer instead.

Fixes #111
